### PR TITLE
Fix: Navigation Bug Where URL Changed But Content Did Not Render

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -15,7 +15,7 @@ const Nav = () => {
     return (
         <nav className="navbar navbar-expand-lg bg-body-tertiary">
             <div className="container-fluid">
-                <a className="navbar-brand" href="#/">
+                <a className="navbar-brand">
                     <img src={Logo} alt="Logo" />
                 </a>
                 <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -24,12 +24,12 @@ const Nav = () => {
                 <div className="collapse navbar-collapse" id="navbarNav">
                     <ul className="navbar-nav me-auto mb-2 mb-lg-0">
                         <li className="nav-item">
-                            <a className={page == "/" ? "nav-link active" : "nav-link"} onClick={() => navigate('/')} href="#/">
+                            <a className={page == "/" ? "nav-link active" : "nav-link"} onClick={() => navigate('/')}>
                                 <i className="fa-solid fa-house-chimney"></i> Inicio
                             </a>
                         </li>
                         <li className="nav-item">
-                            <a className={page == "/about" ? "nav-link active" : "nav-link"} href="#/about" onClick={() => navigate('/about')}>
+                            <a className={page == "/about" ? "nav-link active" : "nav-link"} onClick={() => navigate('/about')}>
                                 <i className="fa-solid fa-circle-info"></i> Sobre nosotros
                             </a>
                         </li>
@@ -37,19 +37,19 @@ const Nav = () => {
                             isLoggedIn ? (
                                 <>
                                     <li className="nav-item">
-                                        <a className={page == "/report" ? "nav-link active" : "nav-link"} href="#/report" onClick={() => navigate('/report')}>
+                                        <a className={page == "/report" ? "nav-link active" : "nav-link"} onClick={() => navigate('/report')}>
                                             <i className="fa-solid fa-chart-line"></i> Reporte
                                         </a>
                                     </li>
                                     <li className="nav-item">
-                                        <a className={page == "/logout" ? "nav-link active" : "nav-link"} href="#/logout" onClick={() => navigate('/logout')}>
+                                        <a className={page == "/logout" ? "nav-link active" : "nav-link"}  onClick={() => navigate('/logout')}>
                                             <i className="fa-solid fa-right-from-bracket"></i> Salir
                                         </a>
                                     </li>
                                 </>
                             ) : (
                                 <li className="nav-item">
-                                    <a className={page == "/login" ? "nav-link active" : "nav-link"} href="#/login" onClick={() => navigate('/login')}>
+                                    <a className={page == "/login" ? "nav-link active" : "nav-link"}  onClick={() => navigate('/login')}>
                                         <i className="fa-solid fa-right-to-bracket"></i> Ingresar
                                     </a>
                                 </li>

--- a/src/hooks/useNavigate.jsx
+++ b/src/hooks/useNavigate.jsx
@@ -16,6 +16,7 @@ const NavigationProvider = ({ children }) => {
     const navigate = (url) => {
         console.log('Pagina actual', url)
         setPage(url)
+        window.location.hash = url;
     }
 
     return (


### PR DESCRIPTION
This pull request addresses a navigation bug in the application. Previously, when a user clicked on a navigation link, the URL would change but the new content would not render. 

![image](https://github.com/menene/react_client/assets/73502425/d3963436-fdc2-4bfe-adf6-33072ff69b3a)
![image](https://github.com/menene/react_client/assets/73502425/c85a0b8b-df85-4583-a6b4-f9efdfac7514)
For example, in the images it is observed that the url does not match the rendering of the content

This was due to a conflict with the href attribute of the `<a>` tags.

The changes in this pull request resolve this issue by updating the `navigate` function in `useNavigate.jsx`. Now, when a user clicks on a navigation link, the `navigate` function updates the `page` state and the `window.location.hash`, ensuring that the new content renders as expected.

Please review these changes and let me know if you have any feedback or questions.